### PR TITLE
Caluculate time between dates for appt requests

### DIFF
--- a/src/components/AdminAppointmentDetailsPopup.tsx
+++ b/src/components/AdminAppointmentDetailsPopup.tsx
@@ -58,6 +58,7 @@ import { Calendar as CalendarIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import ConfirmationEmailData from '@/types/ConfirmationEmailData';
 import PracticeEmailData from '@/types/PracticeEmailData';
+import { updateRequestCreatedTime } from '@/utils/times';
 
 type AdminAppointmentDetailsPopupProps = {
   open: boolean;
@@ -94,6 +95,7 @@ const AdminAppointmentDetailsPopup = ({
     scheduled_time,
     scheduled_by,
     is_cancelled,
+    created_at,
   } = clickedAppointment;
 
   const SEVEN_30_AM_IN_MINUTES = 60 * 7.5;
@@ -268,7 +270,12 @@ const AdminAppointmentDetailsPopup = ({
           <br />A Peek into the Appointment
         </DialogTitle>
       </DialogHeader>
-      <div className="mt-4 px-2 flex gap-4">{renderStatusBadges()}</div>
+      <div className="mt-4 px-2 flex gap-4">
+        {renderStatusBadges()}
+        {!isAppointmentScheduled
+          ? `${updateRequestCreatedTime(created_at!)}`
+          : ``}
+      </div>
       <div className="grid gap-2 py-2 px-2">
         <div className="flex gap-4">
           <h3 className="font-bold">Name :</h3>

--- a/src/components/AdminAppointmentDetailsPopup.tsx
+++ b/src/components/AdminAppointmentDetailsPopup.tsx
@@ -251,6 +251,7 @@ const AdminAppointmentDetailsPopup = ({
     }
     if (!isAppointmentScheduled && !isAppointmentCancelled) {
       statusList.push('Waiting');
+      statusList.push(updateRequestCreatedTime(created_at!));
     }
 
     return statusList.map((status, index) => (
@@ -270,12 +271,7 @@ const AdminAppointmentDetailsPopup = ({
           <br />A Peek into the Appointment
         </DialogTitle>
       </DialogHeader>
-      <div className="mt-4 px-2 flex gap-4">
-        {renderStatusBadges()}
-        {!isAppointmentScheduled
-          ? `${updateRequestCreatedTime(created_at!)}`
-          : ``}
-      </div>
+      <div className="mt-4 px-2 flex gap-4">{renderStatusBadges()}</div>
       <div className="grid gap-2 py-2 px-2">
         <div className="flex gap-4">
           <h3 className="font-bold">Name :</h3>

--- a/src/utils/times.ts
+++ b/src/utils/times.ts
@@ -1,0 +1,31 @@
+const ONE_DAY_IN_MILLISECONDS = 86400000;
+const ONE_HOUR_IN_MILLISECONDS = 3600000;
+
+function getDaysBetweenDates(timeBetween: number) {
+  const daysBetween = timeBetween / ONE_DAY_IN_MILLISECONDS;
+  const days =
+    daysBetween >= 0 ? Math.floor(daysBetween) : Math.ceil(daysBetween);
+
+  if (days === 1) return `Requested 1 day ago`;
+  return `Requested ${days} days ago`;
+}
+
+function getHoursBetweenDates(timeBetween: number) {
+  const hoursBetween = timeBetween / ONE_HOUR_IN_MILLISECONDS;
+  const hours =
+    hoursBetween >= 0 ? Math.floor(hoursBetween) : Math.ceil(hoursBetween);
+
+  if (hours > 24) return getDaysBetweenDates(timeBetween);
+
+  if (hours < 1) return `Requested < 1 hour ago`;
+  else if (hours === 1) return `Requested 1 hour ago`;
+  return `Requested ${hours} hours ago`;
+}
+
+export function updateRequestCreatedTime(dateCreated: string) {
+  const today = new Date();
+  const requestCreated = new Date(dateCreated);
+  const timeBetween = today.getTime() - requestCreated.getTime();
+
+  return getHoursBetweenDates(timeBetween);
+}


### PR DESCRIPTION
## Description

I've added some functions to calculate how many hours and days have passed since an appointment was requested. This will display on the admin appointment popup and will only be seen on appointments before they have been scheduled. 

## Related Issue

closes #112 

## Acceptance Criteria

Add how many hours ago a request has been submitted and have that information appear on the admin appointment popup. Once one day has passed, it should change from tracking how many hours have passed to how many days. This information should not be available on scheduled appointments. 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="571" alt="Screen Shot 2023-09-20 at 4 38 10 PM" src="https://github.com/Full-Stack-Collective/connectient/assets/70449557/83027226-10b9-4b4c-a314-ec6014417235">

### After

![Screen Shot 2023-09-20 at 8 08 03 PM](https://github.com/Full-Stack-Collective/connectient/assets/70449557/507499e2-1823-406d-97b0-79ab03aa7c6a)

![Screen Shot 2023-09-20 at 8 08 31 PM](https://github.com/Full-Stack-Collective/connectient/assets/70449557/c0bdc4cd-4906-43ed-803c-8c66fadb4aa6)

## Testing Steps / QA Criteria

Login to admin and click on any requested appointment in the dashboard. The amount of hours or days since the appointment was requested (which is based on the difference between Today and the created_at date on the appointment) should be shown next to the status badges. This should not be available on scheduled appointments. Any brand new appointments made less than one hour ago should say 'Requested < 1 hour ago'. 
